### PR TITLE
prevent duplicates in github actions

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -1,5 +1,9 @@
-# https://medium.com/@doedotdev/mypy-for-github-action-7da1ebee99e7
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   black:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When working on #9, we were confused by how pytest had run twice, and we were looking at the output of different pytest runs. This PR makes pytest, mypy and black only run once on each pull request.

I don't know how this configuration works, and I copy/pasted it from somewhere a long time ago. But I know it does work. I have used it a lot on many projects, including Porcupine and Mantaray.