### PR TITLE
Tell pytest to not hide its prints

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --capture=no


### PR DESCRIPTION
This PR adds a configuration file that tells pytest to always use `--capture=no`, so that we don't have to remember to specify it every time we want to debug the tests.