### PR TITLE
tests: rename function to receive_line and use it elsewhere

### DIFF
--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -69,7 +69,9 @@ def user_alice(run_server):
 
     # Receiving everything the server is going to send helps prevent errors.
     # Otherwise it might not be fully started yet when the client quits.
-    while receive_line(alice_socket) != b":mantatail 376 Alice :End of /MOTD command\r\n":
+    while (
+        receive_line(alice_socket) != b":mantatail 376 Alice :End of /MOTD command\r\n"
+    ):
         pass
 
     yield alice_socket

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -69,9 +69,8 @@ def user_alice(run_server):
 
     # Receiving everything the server is going to send helps prevent errors.
     # Otherwise it might not be fully started yet when the client quits.
-    received = b""
-    while not received.endswith(b"\r\n:mantatail 376 Alice :End of /MOTD command\r\n"):
-        received += alice_socket.recv(1)
+    while receive_line(alice_socket) != b":mantatail 376 Alice :End of /MOTD command\r\n":
+        pass
 
     yield alice_socket
     alice_socket.sendall(b"QUIT\r\n")
@@ -87,9 +86,8 @@ def user_bob(run_server):
 
     # Receiving everything the server is going to send helps prevent errors.
     # Otherwise it might not be fully started yet when the client quits.
-    received = b""
-    while not received.endswith(b"\r\n:mantatail 376 Bob :End of /MOTD command\r\n"):
-        received += bob_socket.recv(1)
+    while receive_line(bob_socket) != b":mantatail 376 Bob :End of /MOTD command\r\n":
+        pass
 
     yield bob_socket
     bob_socket.sendall(b"QUIT\r\n")
@@ -101,10 +99,10 @@ def user_bob(run_server):
 ##############
 
 
-def recv_loop(user):
+def receive_line(sock):
     received = b""
     while not received.endswith(b"\r\n"):
-        received += user.recv(1)
+        received += sock.recv(1)
     return received
 
 
@@ -117,20 +115,18 @@ def test_join_before_registering(run_server):
     user_socket = socket.socket()
     user_socket.connect(("localhost", 6667))
     user_socket.sendall(b"JOIN #foo\r\n")
-    received = b""
-    while not received.endswith(b"\r\n"):
-        received += user_socket.recv(1)
+    received = receive_line(user_socket)
     assert received == b":mantatail 451 * :You have not registered\r\n"
 
 
 def test_no_such_channel(user_alice):
     user_alice.sendall(b"PART #foo\r\n")
-    received = recv_loop(user_alice)
+    received = receive_line(user_alice)
     assert received == b":mantatail 403 #foo :No such channel\r\n"
 
 
 def test_youre_not_on_that_channel(user_alice, user_bob):
     user_alice.sendall(b"JOIN #foo\r\n")
     user_bob.sendall(b"PART #foo\r\n")
-    received = recv_loop(user_bob)
+    received = receive_line(user_bob)
     assert received == b":mantatail 442 #foo :You're not on that channel\r\n"


### PR DESCRIPTION
`receive_line()` (previously `recv_loop()`, not to be confused with the method of the same name in mantatail.py) takes in a socket as an argument, and receives one line of data from it. This is a useful function, and using it more in `test_mantatail.py` shortens and cleans up the rest of the code.