### PR TITLE
add time.sleep(0.1) and comment to randomly failing test

### DIFF
--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -1,6 +1,7 @@
 import pytest
 import socket
 import threading
+import time
 from mantatail import Server
 
 motd_dict_test = {
@@ -131,7 +132,7 @@ def test_no_such_channel(user_alice):
 
 def test_youre_not_on_that_channel(user_alice, user_bob):
     user_alice.sendall(b"JOIN #foo\r\n")
-    # TODO: wait until server says that join is done, prevents randomly occurring errors
+    time.sleep(0.1)  # TODO: wait until server says that join is done
     user_bob.sendall(b"PART #foo\r\n")
     received = recv_loop(user_bob)
     assert received == b":mantatail 442 #foo :You're not on that channel\r\n"

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -131,6 +131,7 @@ def test_no_such_channel(user_alice):
 
 def test_youre_not_on_that_channel(user_alice, user_bob):
     user_alice.sendall(b"JOIN #foo\r\n")
+    # TODO: wait until server says that join is done, prevents randomly occurring errors
     user_bob.sendall(b"PART #foo\r\n")
     received = recv_loop(user_bob)
     assert received == b":mantatail 442 #foo :You're not on that channel\r\n"


### PR DESCRIPTION
This test fails randomly on my computer, 1 out of 10 times or so. This is because Bob can try to PART the channel while Alice is still joining it, and then error message is `403 #foo :No such channel` instead of `442 #foo :You're not on that channel`, causing the assert to fail.

The correct fix would be to wait until the server says "Alice, you have now finished joining #foo". But currently it doesn't send back anything when the joining is finished, so I'm just leaving a todo comment.