### PR TITLE
Cleanup: move user instantiation check inside else statement

### DIFF
--- a/mantatail.py
+++ b/mantatail.py
@@ -96,12 +96,12 @@ class Server:
                                 )
                             )
 
-                    if _user_name and _nick and user is None:
-                        user = User(user_host, user_socket, _user_name, _nick)
-                        command_handler: IrcCommandHandler = IrcCommandHandler(
-                            self, user
-                        )
-                        command_handler.handle_motd()
+                        if _user_name and _nick:
+                            user = User(user_host, user_socket, _user_name, _nick)
+                            command_handler: IrcCommandHandler = IrcCommandHandler(
+                                self, user
+                            )
+                            command_handler.handle_motd()
 
 
 class User:


### PR DESCRIPTION
We want the user instantiation to happen if `user is None`, and both _nick and _user_name have been given. Having this inside the `else` part of `if user is not None:` makes sense to me, because it contains other related code that runs only when the user is None.