### PR TITLE
tests: Add timeout to receive_line()

### DIFF
--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -103,6 +103,7 @@ def user_bob(run_server):
 
 
 def receive_line(sock):
+    sock.settimeout(1)
     received = b""
     while not received.endswith(b"\r\n"):
         received += sock.recv(1)


### PR DESCRIPTION
The tests will no longer freeze if the server doesn't send anything. Instead, they will wait for one second, and if the server still hasn't sent anything, they fail with an error that looks e.g. like this:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/akuli/MantaTail, configfile: pytest.ini
collected 4 items                                                              

tests/test_mantatail.py .Disconnected.
..Disconnected.
F

=================================== FAILURES ===================================
_______________________________ test_netcatting ________________________________

run_server = None

    def test_netcatting(run_server):
        with socket.socket() as nc:
            nc.connect(("localhost", 6667))  # nc localhost 6667
            nc.sendall(b"NICK nc\n")
            nc.sendall(b"USER nc 0 * :netcat\n")
>           while receive_line(nc) != b":mantatail 376 nc :End of /MOTD command\r\n":

tests/test_mantatail.py:146: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

sock = <socket.socket [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0>

    def receive_line(sock):
        sock.settimeout(1)
        received = b""
        while not received.endswith(b"\r\n"):
>           received += sock.recv(1)
E           socket.timeout: timed out

tests/test_mantatail.py:109: timeout
=========================== short test summary info ============================
FAILED tests/test_mantatail.py::test_netcatting - socket.timeout: timed out
========================= 1 failed, 3 passed in 1.15s ==========================
```