### PR TITLE
Refactor IrcCommandHandler into separate file

### DIFF
--- a/command.py
+++ b/command.py
@@ -30,15 +30,15 @@ def handle_join(server: mantatail.Server, user: mantatail.User, channel_name: st
                 for nick in channel_user_keys:
                     message = f"JOIN {channel_name}"
                     receiver = server.channels[lower_channel_name].user_dict[nick]
-                    receiver.send_string_with_user_prefix(message, user.user_mask)
+                    receiver.send_string_user_mask_prefix(message, user.user_mask)
 
                 # TODO: Implement topic functionality for existing channels & MODE for new ones
 
                 message = f"353 {user.nick} = {channel_name} :{user.nick} {channel_users}"
-                user.send_string_to_user(message)
+                user.send_string(message)
 
                 message = f"366 {user.nick} {channel_name} :End of /NAMES list."
-                user.send_string_to_user(message)
+                user.send_string(message)
 
         # TODO:
         #   * Send topic (332)
@@ -104,7 +104,7 @@ def handle_privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> 
             for user_nick, user in server.channels[lower_channel_name].user_dict.items():
                 if user_nick != lower_sender_nick:
                     message = f"PRIVMSG {receiver} {colon_privmsg}"
-                    user.send_string_with_user_prefix(message, sender_user_mask)
+                    user.send_string_user_mask_prefix(message, sender_user_mask)
 
 
 # Private functions
@@ -124,18 +124,18 @@ def motd(server: mantatail.Server, user: mantatail.User) -> None:
         "end_msg": f"{end_num} {user.nick} {end_info}",
     }
 
-    user.send_string_to_user(motd_start_and_end["start_msg"])
+    user.send_string(motd_start_and_end["start_msg"])
 
     if server.motd_content:
         motd = server.motd_content["motd"]
         for motd_line in motd:
             motd_message = f"{motd_num} {user.nick} :{motd_line.format(user_nick=user.nick)}"
-            user.send_string_to_user(motd_message)
+            user.send_string(motd_message)
     # If motd.json could not be found
     else:
         error_no_motd(user)
 
-    user.send_string_to_user(motd_start_and_end["end_msg"])
+    user.send_string(motd_start_and_end["end_msg"])
 
 
 ### Error Messages
@@ -143,7 +143,7 @@ def error_unknown_command(user: mantatail.User, command: str) -> None:
     (unknown_cmd_num, unknown_cmd_info) = irc_responses.ERR_UNKNOWNCOMMAND
 
     message = f"{unknown_cmd_num} {command} {unknown_cmd_info}"
-    user.send_string_to_user(message)
+    user.send_string(message)
 
 
 def error_not_registered() -> bytes:
@@ -156,31 +156,31 @@ def error_no_motd(user: mantatail.User) -> None:
     (no_motd_num, no_motd_info) = irc_responses.ERR_NOMOTD
 
     message = f"{no_motd_num} {no_motd_info}"
-    user.send_string_to_user(message)
+    user.send_string(message)
 
 
 def error_no_such_nick_channel(user: mantatail.User, channel_name: str) -> None:
     (no_nick_num, no_nick_info) = irc_responses.ERR_NOSUCHNICK
 
     message = f"{no_nick_num} {channel_name} {no_nick_info}"
-    user.send_string_to_user(message)
+    user.send_string(message)
 
 
 def error_not_on_channel(user: mantatail.User, channel_name: str) -> None:
     (not_on_channel_num, not_on_channel_info) = irc_responses.ERR_NOTONCHANNEL
 
     message = f"{not_on_channel_num} {channel_name} {not_on_channel_info}"
-    user.send_string_to_user(message)
+    user.send_string(message)
 
 
 def error_cannot_send_to_channel(user: mantatail.User, channel_name: str) -> None:
     (cant_send_num, cant_send_info) = irc_responses.ERR_CANNOTSENDTOCHAN
 
     message = f"{cant_send_num} {channel_name} {cant_send_info}"
-    user.send_string_to_user(message)
+    user.send_string(message)
 
 
 def error_no_such_channel(user: mantatail.User, channel_name: str) -> None:
     (no_channel_num, no_channel_info) = irc_responses.ERR_NOSUCHCHANNEL
     message = f"{no_channel_num} {channel_name} {no_channel_info}"
-    user.send_string_to_user(message)
+    user.send_string(message)

--- a/command.py
+++ b/command.py
@@ -6,7 +6,9 @@ import irc_responses
 
 ### Handlers
 def handle_join(server: mantatail.Server, user: mantatail.User, channel_name: str) -> None:
-    channel_regex = r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
+    channel_regex = (
+        r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
+    )
 
     lower_channel_name = channel_name.lower()
     with server.channels_and_users_thread_lock:
@@ -22,7 +24,10 @@ def handle_join(server: mantatail.Server, user: mantatail.User, channel_name: st
 
                 channel_user_keys = server.channels[lower_channel_name].user_dict.keys()
                 channel_users = " ".join(
-                    [server.channels[lower_channel_name].user_dict[user_key].nick for user_key in channel_user_keys]
+                    [
+                        server.channels[lower_channel_name].user_dict[user_key].nick
+                        for user_key in channel_user_keys
+                    ]
                 )
 
                 server.channels[lower_channel_name].user_dict[lower_user_nick] = user
@@ -99,7 +104,9 @@ def handle_privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> 
         elif lower_sender_nick not in server.channels[lower_channel_name].user_dict.keys():
             error_cannot_send_to_channel(user, receiver)
         else:
-            sender_user_mask = server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
+            sender_user_mask = (
+                server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
+            )
 
             for user_nick, user in server.channels[lower_channel_name].user_dict.items():
                 if user_nick != lower_sender_nick:

--- a/command.py
+++ b/command.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import re
 import mantatail
 import irc_responses
@@ -5,9 +6,7 @@ import irc_responses
 
 ### Handlers
 def handle_join(server: mantatail.Server, user: mantatail.User, channel_name: str) -> None:
-    channel_regex = (
-        r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
-    )
+    channel_regex = r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
 
     lower_channel_name = channel_name.lower()
     with server.channels_and_users_thread_lock:
@@ -23,10 +22,7 @@ def handle_join(server: mantatail.Server, user: mantatail.User, channel_name: st
 
                 channel_user_keys = server.channels[lower_channel_name].user_dict.keys()
                 channel_users = " ".join(
-                    [
-                        server.channels[lower_channel_name].user_dict[user_key].nick
-                        for user_key in channel_user_keys
-                    ]
+                    [server.channels[lower_channel_name].user_dict[user_key].nick for user_key in channel_user_keys]
                 )
 
                 server.channels[lower_channel_name].user_dict[lower_user_nick] = user
@@ -103,9 +99,7 @@ def handle_privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> 
         elif lower_sender_nick not in server.channels[lower_channel_name].user_dict.keys():
             error_cannot_send_to_channel(user, receiver)
         else:
-            sender_user_mask = (
-                server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
-            )
+            sender_user_mask = server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
 
             for user_nick, user in server.channels[lower_channel_name].user_dict.items():
                 if user_nick != lower_sender_nick:

--- a/command.py
+++ b/command.py
@@ -33,19 +33,16 @@ def handle_join(server: mantatail.Server, user: mantatail.User, channel_name: st
 
                 for nick in channel_user_keys:
                     message = f"JOIN {channel_name}"
-                    message_as_bytes = convert_string_to_server_message(message, user.user_mask)
                     receiver = server.channels[lower_channel_name].user_dict[nick]
-                    send_bytes_to_user(receiver, message_as_bytes)
+                    receiver.send_string_with_user_prefix(message, user.user_mask)
 
                 # TODO: Implement topic functionality for existing channels & MODE for new ones
 
                 message = f"353 {user.nick} = {channel_name} :{user.nick} {channel_users}"
-                message_as_bytes = convert_string_to_server_message(message)
-                send_bytes_to_user(user, message_as_bytes)
+                user.send_string_to_user(message)
 
                 message = f"366 {user.nick} {channel_name} :End of /NAMES list."
-                message_as_bytes = convert_string_to_server_message(message)
-                send_bytes_to_user(user, message_as_bytes)
+                user.send_string_to_user(message)
 
         # TODO:
         #   * Send topic (332)
@@ -113,9 +110,7 @@ def handle_privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> 
             for user_nick, user in server.channels[lower_channel_name].user_dict.items():
                 if user_nick != lower_sender_nick:
                     message = f"PRIVMSG {receiver} {colon_privmsg}"
-                    message_as_bytes = convert_string_to_server_message(message, sender_user_mask)
-
-                    send_bytes_to_user(user, message_as_bytes)
+                    user.send_string_with_user_prefix(message, sender_user_mask)
 
 
 # Private functions
@@ -135,22 +130,18 @@ def motd(server: mantatail.Server, user: mantatail.User) -> None:
         "end_msg": f"{end_num} {user.nick} {end_info}",
     }
 
-    start_message_as_bytes = convert_string_to_server_message(motd_start_and_end["start_msg"])
-    end_message_as_bytes = convert_string_to_server_message(motd_start_and_end["end_msg"])
-
-    send_bytes_to_user(user, start_message_as_bytes)
+    user.send_string_to_user(motd_start_and_end["start_msg"])
 
     if server.motd_content:
         motd = server.motd_content["motd"]
         for motd_line in motd:
             motd_message = f"{motd_num} {user.nick} :{motd_line.format(user_nick=user.nick)}"
-            motd_message_as_bytes = convert_string_to_server_message(motd_message)
-            send_bytes_to_user(user, motd_message_as_bytes)
+            user.send_string_to_user(motd_message)
     # If motd.json could not be found
     else:
         error_no_motd(user)
 
-    send_bytes_to_user(user, end_message_as_bytes)
+    user.send_string_to_user(motd_start_and_end["end_msg"])
 
 
 ### Error Messages
@@ -158,62 +149,44 @@ def error_unknown_command(user: mantatail.User, command: str) -> None:
     (unknown_cmd_num, unknown_cmd_info) = irc_responses.ERR_UNKNOWNCOMMAND
 
     message = f"{unknown_cmd_num} {command} {unknown_cmd_info}"
-    error_message_as_bytes = convert_string_to_server_message(message)
-    send_bytes_to_user(user, error_message_as_bytes)
+    user.send_string_to_user(message)
 
 
 def error_not_registered() -> bytes:
     (not_registered_num, not_registered_info) = irc_responses.ERR_NOTREGISTERED
 
-    message = f"{not_registered_num} * {not_registered_info}"
-    return convert_string_to_server_message(message)
+    return bytes(f":mantatail {not_registered_num} * {not_registered_info}\r\n", encoding="utf-8")
 
 
 def error_no_motd(user: mantatail.User) -> None:
     (no_motd_num, no_motd_info) = irc_responses.ERR_NOMOTD
 
     message = f"{no_motd_num} {no_motd_info}"
-    error_message_as_bytes = convert_string_to_server_message(message)
-    send_bytes_to_user(user, error_message_as_bytes)
+    user.send_string_to_user(message)
 
 
 def error_no_such_nick_channel(user: mantatail.User, channel_name: str) -> None:
     (no_nick_num, no_nick_info) = irc_responses.ERR_NOSUCHNICK
 
     message = f"{no_nick_num} {channel_name} {no_nick_info}"
-    error_message_as_bytes = convert_string_to_server_message(message)
-    send_bytes_to_user(user, error_message_as_bytes)
+    user.send_string_to_user(message)
 
 
 def error_not_on_channel(user: mantatail.User, channel_name: str) -> None:
     (not_on_channel_num, not_on_channel_info) = irc_responses.ERR_NOTONCHANNEL
 
     message = f"{not_on_channel_num} {channel_name} {not_on_channel_info}"
-    error_message_as_bytes = convert_string_to_server_message(message)
-    send_bytes_to_user(user, error_message_as_bytes)
+    user.send_string_to_user(message)
 
 
 def error_cannot_send_to_channel(user: mantatail.User, channel_name: str) -> None:
     (cant_send_num, cant_send_info) = irc_responses.ERR_CANNOTSENDTOCHAN
 
     message = f"{cant_send_num} {channel_name} {cant_send_info}"
-    error_message_as_bytes = convert_string_to_server_message(message)
-    send_bytes_to_user(user, error_message_as_bytes)
+    user.send_string_to_user(message)
 
 
 def error_no_such_channel(user: mantatail.User, channel_name: str) -> None:
     (no_channel_num, no_channel_info) = irc_responses.ERR_NOSUCHCHANNEL
     message = f"{no_channel_num} {channel_name} {no_channel_info}"
-    error_message_as_bytes = convert_string_to_server_message(message)
-    send_bytes_to_user(user, error_message_as_bytes)
-
-
-### Actions
-def convert_string_to_server_message(message: str, prefix: str = "mantatail") -> bytes:
-    utf_8 = "utf-8"
-    suffix = "\r\n"
-    return bytes(f":{prefix} {message}{suffix}", encoding=utf_8)
-
-
-def send_bytes_to_user(receiver: mantatail.User, message: bytes) -> None:
-    receiver.socket.sendall(message)
+    user.send_string_to_user(message)

--- a/handle.py
+++ b/handle.py
@@ -103,7 +103,7 @@ def part(server: mantatail.Server, user: mantatail.User, channel_name: str) -> N
 
 
 # !Not implemented
-def _kick(self, message: str) -> None:
+def _kick(message: str) -> None:
     pass
 
 
@@ -113,7 +113,6 @@ def quit(server: mantatail.Server, user: mantatail.User, channel_name: str) -> N
 
 
 def privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> None:
-    print("NEW")
     with server.channels_and_users_thread_lock:
         (receiver, colon_privmsg) = msg.split(" ", 1)
 
@@ -141,7 +140,7 @@ def privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> None:
 
 
 # !Not implemented
-def privmsg_to_user(receiver, colon_privmsg) -> None:
+def privmsg_to_user(receiver: str, colon_privmsg: str) -> None:
     pass
 
 
@@ -154,6 +153,13 @@ def error_unknown_command(user: mantatail.User, command: str) -> None:
     send_bytes_to_user(user, error_message_as_bytes)
 
 
+def error_not_registered() -> bytes:
+    (not_registered_num, not_registered_info) = irc_responses.ERR_NOTREGISTERED
+
+    message = f"{not_registered_num} * {not_registered_info}"
+    return convert_string_to_server_message(message)
+
+
 def error_no_motd(user: mantatail.User) -> None:
     (no_motd_num, no_motd_info) = irc_responses.ERR_NOMOTD
 
@@ -162,7 +168,7 @@ def error_no_motd(user: mantatail.User) -> None:
     send_bytes_to_user(user, error_message_as_bytes)
 
 
-def error_no_such_nick_channel(user: mantatail.User, channel_name) -> None:
+def error_no_such_nick_channel(user: mantatail.User, channel_name: str) -> None:
     (no_nick_num, no_nick_info) = irc_responses.ERR_NOSUCHNICK
 
     message = f"{no_nick_num} {channel_name} {no_nick_info}"
@@ -178,7 +184,7 @@ def error_not_on_channel(user: mantatail.User, channel_name: str) -> None:
     send_bytes_to_user(user, error_message_as_bytes)
 
 
-def error_cannot_send_to_channel(user: mantatail.User, channel_name) -> None:
+def error_cannot_send_to_channel(user: mantatail.User, channel_name: str) -> None:
     (cant_send_num, cant_send_info) = irc_responses.ERR_CANNOTSENDTOCHAN
 
     message = f"{cant_send_num} {channel_name} {cant_send_info}"
@@ -195,7 +201,7 @@ def error_no_such_channel(user: mantatail.User, channel_name: str) -> None:
 
 
 ### Actions
-def convert_string_to_server_message(message: str, prefix="mantatail") -> bytes:
+def convert_string_to_server_message(message: str, prefix: str = "mantatail") -> bytes:
     utf_8 = "utf-8"
     suffix = "\r\n"
     return bytes(f":{prefix} {message}{suffix}", encoding=utf_8)

--- a/handle.py
+++ b/handle.py
@@ -33,7 +33,9 @@ def motd(server: mantatail.Server, user: mantatail.User) -> None:
 
 
 def join(server: mantatail.Server, user: mantatail.User, channel_name: str) -> None:
-    channel_regex = r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
+    channel_regex = (
+        r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
+    )
 
     lower_channel_name = channel_name.lower()
     with server.channels_and_users_thread_lock:
@@ -49,7 +51,10 @@ def join(server: mantatail.Server, user: mantatail.User, channel_name: str) -> N
 
                 channel_user_keys = server.channels[lower_channel_name].user_dict.keys()
                 channel_users = " ".join(
-                    [server.channels[lower_channel_name].user_dict[user_key].nick for user_key in channel_user_keys]
+                    [
+                        server.channels[lower_channel_name].user_dict[user_key].nick
+                        for user_key in channel_user_keys
+                    ]
                 )
 
                 server.channels[lower_channel_name].user_dict[lower_user_nick] = user
@@ -129,7 +134,9 @@ def privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> None:
         elif lower_sender_nick not in server.channels[lower_channel_name].user_dict.keys():
             error_cannot_send_to_channel(user, receiver)
         else:
-            sender_user_mask = server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
+            sender_user_mask = (
+                server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
+            )
 
             for user_nick, user in server.channels[lower_channel_name].user_dict.items():
                 if user_nick != lower_sender_nick:

--- a/handle.py
+++ b/handle.py
@@ -1,0 +1,205 @@
+import re
+import mantatail
+import irc_responses
+
+
+### Handlers
+def motd(server: mantatail.Server, user: mantatail.User) -> None:
+    (start_num, start_info) = irc_responses.RPL_MOTDSTART
+    motd_num = irc_responses.RPL_MOTD
+    (end_num, end_info) = irc_responses.RPL_ENDOFMOTD
+
+    motd_start_and_end = {
+        "start_msg": f"{start_num} {user.nick} :- mantatail {start_info}",
+        "end_msg": f"{end_num} {user.nick} {end_info}",
+    }
+
+    start_message_as_bytes = convert_string_to_server_message(motd_start_and_end["start_msg"])
+    end_message_as_bytes = convert_string_to_server_message(motd_start_and_end["end_msg"])
+
+    send_bytes_to_user(user, start_message_as_bytes)
+
+    if server.motd_content:
+        motd = server.motd_content["motd"]
+        for motd_line in motd:
+            motd_message = f"{motd_num} {user.nick} :{motd_line.format(user_nick=user.nick)}"
+            motd_message_as_bytes = convert_string_to_server_message(motd_message)
+            send_bytes_to_user(user, motd_message_as_bytes)
+    # If motd.json could not be found
+    else:
+        error_no_motd(user)
+
+    send_bytes_to_user(user, end_message_as_bytes)
+
+
+def join(server: mantatail.Server, user: mantatail.User, channel_name: str) -> None:
+    channel_regex = r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
+
+    lower_channel_name = channel_name.lower()
+    with server.channels_and_users_thread_lock:
+        if not re.match(channel_regex, lower_channel_name):
+            error_no_such_channel(user, channel_name)
+        else:
+            if lower_channel_name not in server.channels.keys():
+                server.channels[lower_channel_name] = mantatail.Channel(channel_name, user.nick)
+
+            lower_user_nick = user.nick.lower()
+
+            if lower_user_nick not in server.channels[lower_channel_name].user_dict.keys():
+
+                channel_user_keys = server.channels[lower_channel_name].user_dict.keys()
+                channel_users = " ".join(
+                    [server.channels[lower_channel_name].user_dict[user_key].nick for user_key in channel_user_keys]
+                )
+
+                server.channels[lower_channel_name].user_dict[lower_user_nick] = user
+
+                for nick in channel_user_keys:
+                    message = f"JOIN {channel_name}"
+                    message_as_bytes = convert_string_to_server_message(message, user.user_mask)
+                    receiver = server.channels[lower_channel_name].user_dict[nick]
+                    send_bytes_to_user(receiver, message_as_bytes)
+
+                # TODO: Implement topic functionality for existing channels & MODE for new ones
+
+                message = f"353 {user.nick} = {channel_name} :{user.nick} {channel_users}"
+                message_as_bytes = convert_string_to_server_message(message)
+                send_bytes_to_user(user, message_as_bytes)
+
+                message = f"366 {user.nick} {channel_name} :End of /NAMES list."
+                message_as_bytes = convert_string_to_server_message(message)
+                send_bytes_to_user(user, message_as_bytes)
+
+        # TODO:
+        #   * Send topic (332)
+        #   * Optional/Later: (333) https://modern.ircdocs.horse/#rpltopicwhotime-333
+        #   * Send Name list (353)
+        #   * Send End of Name list (366)
+
+        # TODO: Check for:
+        #   * User invited to channel
+        #   * Nick/user not matching bans
+        #   * Eventual password matches
+        #   * Not joined too many channels
+
+        # TODO:
+        #   * Forward to another channel (irc num 470) ex. #homebrew -> ##homebrew
+
+
+def part(server: mantatail.Server, user: mantatail.User, channel_name: str) -> None:
+    # TODO: Show part message to other users & Remove from user from channel user list.
+    lower_channel_name = channel_name.lower()
+    lower_user_nick = user.nick.lower()
+
+    with server.channels_and_users_thread_lock:
+        if lower_channel_name not in server.channels.keys():
+            error_no_such_channel(user, channel_name)
+        elif lower_user_nick not in server.channels[lower_channel_name].user_dict.keys():
+            error_not_on_channel(user, channel_name)
+        else:
+            del server.channels[lower_channel_name].user_dict[lower_user_nick]
+            if len(server.channels[lower_channel_name].user_dict) == 0:
+                del server.channels[lower_channel_name]
+
+
+# !Not implemented
+def _kick(self, message: str) -> None:
+    pass
+
+
+def quit(server: mantatail.Server, user: mantatail.User, channel_name: str) -> None:
+    user.closed_connection = True
+    user.socket.close()
+
+
+def privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> None:
+    print("NEW")
+    with server.channels_and_users_thread_lock:
+        (receiver, colon_privmsg) = msg.split(" ", 1)
+
+        assert colon_privmsg.startswith(":")
+
+        lower_sender_nick = user.nick.lower()
+        lower_channel_name = receiver.lower()
+
+        if not receiver.startswith("#"):
+            privmsg_to_user(receiver, colon_privmsg)
+        elif lower_channel_name not in server.channels.keys():
+            error_no_such_nick_channel(user, receiver)
+
+        elif lower_sender_nick not in server.channels[lower_channel_name].user_dict.keys():
+            error_cannot_send_to_channel(user, receiver)
+        else:
+            sender_user_mask = server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
+
+            for user_nick, user in server.channels[lower_channel_name].user_dict.items():
+                if user_nick != lower_sender_nick:
+                    message = f"PRIVMSG {receiver} {colon_privmsg}"
+                    message_as_bytes = convert_string_to_server_message(message, sender_user_mask)
+
+                    send_bytes_to_user(user, message_as_bytes)
+
+
+# !Not implemented
+def privmsg_to_user(receiver, colon_privmsg) -> None:
+    pass
+
+
+### Error Messages
+def error_unknown_command(user: mantatail.User, command: str) -> None:
+    (unknown_cmd_num, unknown_cmd_info) = irc_responses.ERR_UNKNOWNCOMMAND
+
+    message = f"{unknown_cmd_num} {command} {unknown_cmd_info}"
+    error_message_as_bytes = convert_string_to_server_message(message)
+    send_bytes_to_user(user, error_message_as_bytes)
+
+
+def error_no_motd(user: mantatail.User) -> None:
+    (no_motd_num, no_motd_info) = irc_responses.ERR_NOMOTD
+
+    message = f"{no_motd_num} {no_motd_info}"
+    error_message_as_bytes = convert_string_to_server_message(message)
+    send_bytes_to_user(user, error_message_as_bytes)
+
+
+def error_no_such_nick_channel(user: mantatail.User, channel_name) -> None:
+    (no_nick_num, no_nick_info) = irc_responses.ERR_NOSUCHNICK
+
+    message = f"{no_nick_num} {channel_name} {no_nick_info}"
+    error_message_as_bytes = convert_string_to_server_message(message)
+    send_bytes_to_user(user, error_message_as_bytes)
+
+
+def error_not_on_channel(user: mantatail.User, channel_name: str) -> None:
+    (not_on_channel_num, not_on_channel_info) = irc_responses.ERR_NOTONCHANNEL
+
+    message = f"{not_on_channel_num} {channel_name} {not_on_channel_info}"
+    error_message_as_bytes = convert_string_to_server_message(message)
+    send_bytes_to_user(user, error_message_as_bytes)
+
+
+def error_cannot_send_to_channel(user: mantatail.User, channel_name) -> None:
+    (cant_send_num, cant_send_info) = irc_responses.ERR_CANNOTSENDTOCHAN
+
+    message = f"{cant_send_num} {channel_name} {cant_send_info}"
+    error_message_as_bytes = convert_string_to_server_message(message)
+    send_bytes_to_user(user, error_message_as_bytes)
+
+
+def error_no_such_channel(user: mantatail.User, channel_name: str) -> None:
+    (no_channel_num, no_channel_info) = irc_responses.ERR_NOSUCHCHANNEL
+
+    message = f"{no_channel_num} {channel_name} {no_channel_info}"
+    error_message_as_bytes = convert_string_to_server_message(message)
+    send_bytes_to_user(user, error_message_as_bytes)
+
+
+### Actions
+def convert_string_to_server_message(message: str, prefix="mantatail") -> bytes:
+    utf_8 = "utf-8"
+    suffix = "\r\n"
+    return bytes(f":{prefix} {message}{suffix}", encoding=utf_8)
+
+
+def send_bytes_to_user(receiver: mantatail.User, message: bytes) -> None:
+    receiver.socket.sendall(message)

--- a/mantatail.py
+++ b/mantatail.py
@@ -81,10 +81,10 @@ class Server:
                         try:
                             # ex. "command.handle_nick" or "command.handle_join"
                             call_handler_function = getattr(command, parsed_command)
-                            call_handler_function(self, user, message)
-
                         except AttributeError:
                             command.error_unknown_command(user, verb_lower)
+                        else:
+                            call_handler_function(self, user, message)
 
                         if user.closed_connection:
                             return
@@ -101,13 +101,11 @@ class User:
         self.user_mask = f"{self.nick}!{self.user_name}@{self.host}"
         self.closed_connection = False
 
-    def send_string_to_user(self, message: str) -> None:
+    def send_string(self, message: str) -> None:
         message_as_bytes = bytes(f":mantatail {message}\r\n", encoding="utf-8")
         self.socket.sendall(message_as_bytes)
 
-    def send_string_with_user_prefix(self, message: str, prefix: str) -> None:
-        if not prefix:
-            prefix = self.user_mask
+    def send_string_user_mask_prefix(self, message: str, prefix: str) -> None:
         message_as_bytes = bytes(f":{prefix} {message}\r\n", encoding="utf-8")
         self.socket.sendall(message_as_bytes)
 

--- a/mantatail.py
+++ b/mantatail.py
@@ -101,6 +101,16 @@ class User:
         self.user_mask = f"{self.nick}!{self.user_name}@{self.host}"
         self.closed_connection = False
 
+    def send_string_to_user(self, message: str) -> None:
+        message_as_bytes = bytes(f":mantatail {message}\r\n", encoding="utf-8")
+        self.socket.sendall(message_as_bytes)
+
+    def send_string_with_user_prefix(self, message: str, prefix: str) -> None:
+        if not prefix:
+            prefix = self.user_mask
+        message_as_bytes = bytes(f":{prefix} {message}\r\n", encoding="utf-8")
+        self.socket.sendall(message_as_bytes)
+
 
 class Channel:
     def __init__(self, channel_name: str, channel_creator: str) -> None:

--- a/mantatail.py
+++ b/mantatail.py
@@ -4,6 +4,8 @@ import threading
 import json
 from typing import Dict, Optional, List, Tuple
 
+import command
+
 
 class Server:
     def __init__(self, port: int, motd_content: Optional[Dict[str, List[str]]]) -> None:
@@ -30,8 +32,6 @@ class Server:
             client_thread.start()
 
     def recv_loop(self, user_info: Tuple[str, socket.socket]) -> None:
-        import command
-
         user_host = user_info[0]
         user_socket = user_info[1]
         _user_message = None

--- a/mantatail.py
+++ b/mantatail.py
@@ -79,7 +79,7 @@ class Server:
 
                     else:
                         try:
-                            # ex. "handle.nick" or "handle.join"
+                            # ex. "command.handle_nick" or "command.handle_join"
                             call_handler_function = getattr(command, parsed_command)
                             call_handler_function(self, user, message)
 

--- a/mantatail.py
+++ b/mantatail.py
@@ -6,6 +6,7 @@ import json
 from typing import Dict, Optional, List, Tuple
 
 import irc_responses
+import handle
 
 
 class Server:
@@ -66,8 +67,8 @@ class Server:
 
                     verb_lower = verb.lower()
 
-                    # ex. "handle_nick" or "handle_join"
-                    handler_function_to_call = "handle_" + verb_lower
+                    # ex. "handle.nick" or "handle.join"
+                    # handler_function_to_call = "handle." + verb_lower
 
                     if user is None:
                         if verb_lower == "user":
@@ -76,25 +77,29 @@ class Server:
                             _nick = message
                         else:
                             (error_code, error_info) = irc_responses.ERR_NOTREGISTERED
-                            user_socket.sendall(
-                                bytes(
-                                    f":mantatail {error_code} * {error_info}\r\n", encoding="utf-8"
-                                )
-                            )
+                            user_socket.sendall(bytes(f":mantatail {error_code} * {error_info}\r\n", encoding="utf-8"))
 
                         if _user_message and _nick:
                             user = User(user_host, user_socket, _user_message, _nick)
-                            command_handler: IrcCommandHandler = IrcCommandHandler(self, user)
-                            command_handler.handle_motd()
+                            handle.motd(self, user)
 
                     else:
                         try:
-                            call_handler_function = getattr(
-                                command_handler, handler_function_to_call
-                            )
-                            call_handler_function(message)
+                            call_handler_function = getattr(handle, verb_lower)
+
                         except AttributeError:
-                            command_handler.handle_unknown_command(verb_lower)
+                            print("attr1")
+                            # ! for refactor - remove later
+                            handler_function_to_call = "handle_" + verb_lower
+                            try:
+                                print("try2")
+                                call_handler_function = getattr(command_handler, handler_function_to_call)
+                                call_handler_function(message)
+                            except AttributeError:
+                                print("attr2")
+                                handle.error_unknown_command(user, verb)
+                        else:
+                            call_handler_function(self, user, message)
 
                         if user.closed_connection:
                             return
@@ -120,188 +125,13 @@ class Channel:
         self.user_dict: Dict[Optional[str], User] = {}
 
 
-class IrcCommandHandler:
-    def __init__(self, server: Server, user: User) -> None:
-        self.encoding = "utf-8"
-        self.send_to_client_prefix = ":mantatail"
-        self.send_to_client_suffix = "\r\n"
-        self.server = server
-        self.user = user
-
-    def handle_motd(self) -> None:
-        (start_num, start_info) = irc_responses.RPL_MOTDSTART
-        motd_num = irc_responses.RPL_MOTD
-        (end_num, end_info) = irc_responses.RPL_ENDOFMOTD
-
-        motd_start_and_end = {
-            "start_msg": f"{self.send_to_client_prefix} {start_num} {self.user.nick} :- mantatail {start_info}{self.send_to_client_suffix}",
-            "end_msg": f"{self.send_to_client_prefix} {end_num} {self.user.nick} {end_info}{self.send_to_client_suffix}",
-        }
-
-        start_msg = bytes(motd_start_and_end["start_msg"], encoding=self.encoding)
-        end_msg = bytes(motd_start_and_end["end_msg"], encoding=self.encoding)
-
-        self.user.socket.sendall(start_msg)
-
-        if self.server.motd_content:
-            motd = self.server.motd_content["motd"]
-            for motd_line in motd:
-                motd_msg = bytes(
-                    f"{self.send_to_client_prefix} {motd_num} {self.user.nick} :{motd_line.format(user_nick=self.user.nick)}{self.send_to_client_suffix}",
-                    encoding=self.encoding,
-                )
-                self.user.socket.sendall(motd_msg)
-        # If motd.json could not be found
-        else:
-            (no_motd_num, no_motd_info) = irc_responses.ERR_NOMOTD
-            self.user.socket.sendall(
-                bytes(
-                    f"{self.send_to_client_prefix} {no_motd_num} {no_motd_info}{self.send_to_client_suffix}",
-                    encoding=self.encoding,
-                )
-            )
-
-        self.user.socket.sendall(end_msg)
-
-    def handle_join(self, channel_name: str) -> None:
-        channel_regex = (
-            r"#[^ \x07,]{1,49}"  # TODO: Make more restrictive (currently valid: ###, #ö?!~ etc)
-        )
-
-        lower_channel_name = channel_name.lower()
-        with self.server.channels_and_users_thread_lock:
-            if not re.match(channel_regex, lower_channel_name):
-                self.handle_no_such_channel(channel_name)
-            else:
-                if lower_channel_name not in self.server.channels.keys():
-                    self.server.channels[lower_channel_name] = Channel(channel_name, self.user.nick)
-
-                lower_user_nick = self.user.nick.lower()
-
-                if lower_user_nick not in self.server.channels[lower_channel_name].user_dict.keys():
-
-                    channel_user_keys = self.server.channels[lower_channel_name].user_dict.keys()
-                    channel_users = " ".join(
-                        [
-                            self.server.channels[lower_channel_name].user_dict[user_key].nick
-                            for user_key in channel_user_keys
-                        ]
-                    )
-
-                    self.server.channels[lower_channel_name].user_dict[lower_user_nick] = self.user
-
-                    for user in channel_user_keys:
-                        self.server.channels[lower_channel_name].user_dict[user].socket.sendall(
-                            bytes(
-                                f":{self.user.user_mask} JOIN {channel_name}{self.send_to_client_suffix}",
-                                encoding=self.encoding,
-                            )
-                        )
-
-                    # TODO: Implement topic functionality for existing channels & MODE for new ones
-
-                    self.user.socket.sendall(
-                        bytes(
-                            f"{self.send_to_client_prefix} 353 {self.user.nick} = {channel_name} :{self.user.nick} {channel_users}{self.send_to_client_suffix}",
-                            encoding=self.encoding,
-                        )
-                    )
-                    self.user.socket.sendall(
-                        bytes(
-                            f"{self.send_to_client_prefix} 366 {self.user.nick} {channel_name} :End of /NAMES list.{self.send_to_client_suffix}",
-                            encoding=self.encoding,
-                        )
-                    )
-
-        # TODO:
-        #   * Send topic (332)
-        #   * Optional/Later: (333) https://modern.ircdocs.horse/#rpltopicwhotime-333
-        #   * Send Name list (353)
-        #   * Send End of Name list (366)
-
-        # TODO: Check for:
-        #   * User invited to channel
-        #   * Nick/user not matching bans
-        #   * Eventual password matches
-        #   * Not joined too many channels
-
-        # TODO:
-        #   * Forward to another channel (irc num 470) ex. #homebrew -> ##homebrew
-
-    def handle_part(self, channel_name: str) -> None:
-        # TODO: Show part message to other users & Remove from user from channel user list.
-        lower_channel_name = channel_name.lower()
-        lower_user_nick = self.user.nick.lower()
-
-        with self.server.channels_and_users_thread_lock:
-            if lower_channel_name not in self.server.channels.keys():
-                self.handle_no_such_channel(channel_name)
-            elif lower_user_nick not in self.server.channels[lower_channel_name].user_dict.keys():
-                (not_on_channel_num, not_on_channel_info) = irc_responses.ERR_NOTONCHANNEL
-
-                self.generate_error_reply(not_on_channel_num, not_on_channel_info, channel_name)
-            else:
-                del self.server.channels[lower_channel_name].user_dict[lower_user_nick]
-                if len(self.server.channels[lower_channel_name].user_dict) == 0:
-                    del self.server.channels[lower_channel_name]
-
-    def handle_quit(self, message: str) -> None:
-        self.user.closed_connection = True
-        self.user.socket.close()
-
-    def _handle_kick(self, message: str) -> None:
-        pass
-
-    def handle_privmsg(self, message: str) -> None:
-        with self.server.channels_and_users_thread_lock:
-            (receiver, colon_privmsg) = message.split(" ", 1)
-
-            assert colon_privmsg.startswith(":")
-
-            lower_sender_nick = self.user.nick.lower()
-            lower_channel_name = receiver.lower()
-
-            if not receiver.startswith("#"):
-                self.handle_privmsg_to_user(receiver, colon_privmsg)
-            elif lower_channel_name not in self.server.channels.keys():
-                no_nick_num, no_nick_info = irc_responses.ERR_NOSUCHNICK
-                self.generate_error_reply(no_nick_num, no_nick_info, receiver)
-            elif lower_sender_nick not in self.server.channels[lower_channel_name].user_dict.keys():
-                cant_send_num, cant_send_info = irc_responses.ERR_CANNOTSENDTOCHAN
-                self.generate_error_reply(cant_send_num, cant_send_info, receiver)
-            else:
-                sender_user_mask = (
-                    self.server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
-                )
-
-                for user_nick, user in self.server.channels[lower_channel_name].user_dict.items():
-                    if user_nick != lower_sender_nick:
-                        user.socket.sendall(
-                            bytes(
-                                f":{sender_user_mask} PRIVMSG {receiver} {colon_privmsg}{self.send_to_client_suffix}",
-                                encoding=self.encoding,
-                            )
-                        )
-
-    def handle_privmsg_to_user(self, receiver: str, message: str) -> None:
-        pass
-
-    def handle_unknown_command(self, command: str) -> None:
-        (unknown_cmd_num, unknown_cmd_info) = irc_responses.ERR_UNKNOWNCOMMAND
-
-        self.generate_error_reply(unknown_cmd_num, unknown_cmd_info, command)
-
-    def handle_no_such_channel(self, channel_name: str) -> None:
-        (no_channel_num, no_channel_info) = irc_responses.ERR_NOSUCHCHANNEL
-        self.generate_error_reply(no_channel_num, no_channel_info, channel_name)
-
-    def generate_error_reply(self, error_num: str, error_info: str, error_topic: str) -> None:
-        self.user.socket.sendall(
-            bytes(
-                f"{self.send_to_client_prefix} {error_num} {error_topic} {error_info}{self.send_to_client_suffix}",
-                encoding=self.encoding,
-            )
-        )
+# class IrcCommandHandler:
+#     def __init__(self, server: Server, user: User) -> None:
+#         self.encoding = "utf-8"
+#         self.send_to_client_prefix = ":mantatail"
+#         self.send_to_client_suffix = "\r\n"
+#         self.server = server
+#         self.user = user
 
 
 def split_on_new_line(string: str) -> List[str]:

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -4,9 +4,8 @@ import socket
 import traceback
 import threading
 import time
-import mantatail
 
-# from mantatail import Server
+from mantatail import Server
 
 # fmt: off
 motd_dict_test = {
@@ -49,7 +48,7 @@ def fail_test_if_there_is_an_error_in_a_thread(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def run_server(fail_test_if_there_is_an_error_in_a_thread):
-    server = mantatail.Server(6667, motd_dict_test)
+    server = Server(6667, motd_dict_test)
 
     def run_server(server):
         try:

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -4,18 +4,12 @@ import socket
 import traceback
 import threading
 import time
-from mantatail import Server
+import mantatail
+
+# from mantatail import Server
 
 motd_dict_test = {
-    "motd": [
-        "- Hello {user_nick}, this is a test MOTD!",
-        "-",
-        "- Foo",
-        "- Bar",
-        "- Baz",
-        "-",
-        "- End test MOTD",
-    ]
+    "motd": ["- Hello {user_nick}, this is a test MOTD!", "-", "- Foo", "- Bar", "- Baz", "-", "- End test MOTD"]
 }
 
 ##############
@@ -44,7 +38,7 @@ def fail_test_if_there_is_an_error_in_a_thread(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def run_server(fail_test_if_there_is_an_error_in_a_thread):
-    server = Server(6667, motd_dict_test)
+    server = mantatail.Server(6667, motd_dict_test)
 
     def run_server(server):
         try:

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -8,6 +8,7 @@ import mantatail
 
 # from mantatail import Server
 
+# fmt: off
 motd_dict_test = {
     "motd": [
         "- Hello {user_nick}, this is a test MOTD!",
@@ -16,9 +17,11 @@ motd_dict_test = {
         "- Bar",
         "- Baz",
         "-",
-        "- End test MOTD",
-    ]
+        "- End test MOTD"
+        ]
 }
+
+# fmt: on
 
 ##############
 #  FIXTURES  #

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -9,7 +9,15 @@ import mantatail
 # from mantatail import Server
 
 motd_dict_test = {
-    "motd": ["- Hello {user_nick}, this is a test MOTD!", "-", "- Foo", "- Bar", "- Baz", "-", "- End test MOTD"]
+    "motd": [
+        "- Hello {user_nick}, this is a test MOTD!",
+        "-",
+        "- Foo",
+        "- Bar",
+        "- Baz",
+        "-",
+        "- End test MOTD",
+    ]
 }
 
 ##############


### PR DESCRIPTION
Pytest was complaining about circular imports. I tried to use if TYPE_CHECKING, but with no luck. Pytest gave different AttributeErrors, for example, it didn't like `func(server: Server)`.

I got some help in `#python`, and the best solution we could get to was importing handle inside of `recv_loop()`.
They did however say that imports in method usually means smelly code. He thought the best option was to put the functions in `handle.py` in a class.

He also said he didn't like the `getattr()` solution for a module. He talked about a `@register` decorator to use with a dict. I'm not sure how that would be done, if it's really a better solution. What do you think?

Here are parts of our conversation:

![Skärmavbild 2021-12-30 kl  01 31 12](https://user-images.githubusercontent.com/76887896/147712605-a696e31a-9a52-4f48-9397-289d7488cdc5.png)

![Skärmavbild 2021-12-30 kl  01 31 39](https://user-images.githubusercontent.com/76887896/147712610-84639cb0-6351-4e43-af6e-a59dbaaa2bbf.png)


