### PR TITLE
Combine send_string_user_mask_prefix and send_string

### DIFF
--- a/command.py
+++ b/command.py
@@ -35,7 +35,7 @@ def handle_join(server: mantatail.Server, user: mantatail.User, channel_name: st
                 for nick in channel_user_keys:
                     message = f"JOIN {channel_name}"
                     receiver = server.channels[lower_channel_name].user_dict[nick]
-                    receiver.send_string_user_mask_prefix(message, user.user_mask)
+                    receiver.send_string(message, prefix=user.user_mask)
 
                 # TODO: Implement topic functionality for existing channels & MODE for new ones
 
@@ -104,14 +104,12 @@ def handle_privmsg(server: mantatail.Server, user: mantatail.User, msg: str) -> 
         elif lower_sender_nick not in server.channels[lower_channel_name].user_dict.keys():
             error_cannot_send_to_channel(user, receiver)
         else:
-            sender_user_mask = (
-                server.channels[lower_channel_name].user_dict[lower_sender_nick].user_mask
-            )
+            sender = server.channels[lower_channel_name].user_dict[lower_sender_nick]
 
             for user_nick, user in server.channels[lower_channel_name].user_dict.items():
                 if user_nick != lower_sender_nick:
                     message = f"PRIVMSG {receiver} {colon_privmsg}"
-                    user.send_string_user_mask_prefix(message, sender_user_mask)
+                    user.send_string(message, prefix=sender.user_mask)
 
 
 # Private functions

--- a/mantatail.py
+++ b/mantatail.py
@@ -101,11 +101,7 @@ class User:
         self.user_mask = f"{self.nick}!{self.user_name}@{self.host}"
         self.closed_connection = False
 
-    def send_string(self, message: str) -> None:
-        message_as_bytes = bytes(f":mantatail {message}\r\n", encoding="utf-8")
-        self.socket.sendall(message_as_bytes)
-
-    def send_string_user_mask_prefix(self, message: str, prefix: str) -> None:
+    def send_string(self, message: str, prefix: str = "mantatail") -> None:
         message_as_bytes = bytes(f":{prefix} {message}\r\n", encoding="utf-8")
         self.socket.sendall(message_as_bytes)
 


### PR DESCRIPTION
`send_string` does everything that `send_string_user_mask_prefix` does, but with `"mantatail"` instead of a user's mask as the prefix. Combine both functions together, using a default value of `"mantatail"` for the mask argument.