### PR TITLE
Implement logic to send PING to clients

### DIFF
--- a/command.py
+++ b/command.py
@@ -144,6 +144,11 @@ def handle_privmsg(state: mantatail.ServerState, user: mantatail.UserConnection,
                 usr.send_que.put((message, user.user_mask))
 
 
+def handle_pong(state: mantatail.ServerState, user: mantatail.UserConnection, msg: str) -> None:
+    if msg == ":mantatail":
+        user.pong_received = True
+
+
 # Private functions
 
 # !Not implemented

--- a/command.py
+++ b/command.py
@@ -146,8 +146,7 @@ def handle_privmsg(state: mantatail.ServerState, user: mantatail.UserConnection,
 
 def handle_pong(state: mantatail.ServerState, user: mantatail.UserConnection, msg: str) -> None:
     if msg == ":mantatail":
-        user.pong_received = True
-        user.ping_timer.cancel()
+        user.pong_timer.cancel()
 
 
 # Private functions

--- a/command.py
+++ b/command.py
@@ -146,7 +146,7 @@ def handle_privmsg(state: mantatail.ServerState, user: mantatail.UserConnection,
 
 def handle_pong(state: mantatail.ServerState, user: mantatail.UserConnection, msg: str) -> None:
     if msg == ":mantatail":
-        user.pong_timer.cancel()
+        user.pong_received = True
 
 
 # Private functions

--- a/command.py
+++ b/command.py
@@ -147,6 +147,7 @@ def handle_privmsg(state: mantatail.ServerState, user: mantatail.UserConnection,
 def handle_pong(state: mantatail.ServerState, user: mantatail.UserConnection, msg: str) -> None:
     if msg == ":mantatail":
         user.pong_received = True
+        user.ping_timer.cancel()
 
 
 # Private functions

--- a/mantatail.py
+++ b/mantatail.py
@@ -136,6 +136,7 @@ class UserConnection:
         self.user_mask = f"{self.nick}!{self.user_name}@{self.host}"
         self.que_thread = threading.Thread(target=self.send_queue_thread)
         self.que_thread.start()
+        self.pong_received = False
 
     def send_queue_thread(self) -> None:
         while True:
@@ -195,10 +196,13 @@ class UserConnection:
 
     def queue_ping_message(self) -> None:
         self.send_que.put(("PING :mantatail", "mantatail"))
-        self.pong_timer = threading.Timer(5, self.on_no_pong_received).start()
+        threading.Timer(5, self.assert_pong_received).start()
 
-    def on_no_pong_received(self) -> None:
-        self.send_que.put((None, None))
+    def assert_pong_received(self) -> None:
+        if not self.pong_received:
+            self.send_que.put((None, None))
+        else:
+            self.pong_received = False
 
 
 class Channel:

--- a/mantatail.py
+++ b/mantatail.py
@@ -187,7 +187,7 @@ class UserConnection:
         except OSError:
             return
 
-    def start_ping_timer(self):
+    def start_ping_timer(self) -> None:
         self.ping_timer = threading.Timer(TIMER_SECONDS, self.queue_ping_message)
         self.ping_timer.start()
 

--- a/mantatail.py
+++ b/mantatail.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, List, Set, Tuple
 import command
 
 # Global so that it can be accessed from pytest
-TIMER_SECONDS = 10
+TIMER_SECONDS = 600
 
 
 class ServerState:

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -163,7 +163,7 @@ def test_join_before_registering(run_server):
 def test_ping_message(monkeypatch, user_alice):
     monkeypatch.setattr(mantatail, "TIMER_SECONDS", 3)
     user_alice.sendall(b"JOIN #foo\r\n")
-    assert receive_line(user_alice) == b":Alice!AliceUsr@127.0.0.1 JOIN #foo\r\n"
+
     while receive_line(user_alice) == b":mantatail PING :mantatail\r\n":
         pass
 

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -5,6 +5,7 @@ import traceback
 import threading
 import time
 
+import mantatail
 from mantatail import Listener
 
 # Tests that are known to fail can be decorated with:
@@ -157,6 +158,16 @@ def test_join_before_registering(run_server):
     user_socket.connect(("localhost", 6667))
     user_socket.sendall(b"JOIN #foo\r\n")
     assert receive_line(user_socket) == b":mantatail 451 * :You have not registered\r\n"
+
+
+def test_ping_message(monkeypatch, user_alice):
+    monkeypatch.setattr(mantatail, "TIMER_SECONDS", 3)
+    user_alice.sendall(b"JOIN #foo\r\n")
+    assert receive_line(user_alice) == b":Alice!AliceUsr@127.0.0.1 JOIN #foo\r\n"
+    while receive_line(user_alice) == b":mantatail PING :mantatail\r\n":
+        pass
+
+    user_alice.sendall(b"PONG :mantatail\r\n")
 
 
 def test_join_channel(user_alice, user_bob):

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -134,8 +134,8 @@ def user_charlie(run_server):
 ##############
 
 
-def receive_line(sock):
-    sock.settimeout(1)
+def receive_line(sock, timeout=1):
+    sock.settimeout(timeout)
     received = b""
     while not received.endswith(b"\r\n"):
         received += sock.recv(1)
@@ -161,10 +161,10 @@ def test_join_before_registering(run_server):
 
 
 def test_ping_message(monkeypatch, user_alice):
-    monkeypatch.setattr(mantatail, "TIMER_SECONDS", 3)
+    monkeypatch.setattr(mantatail, "TIMER_SECONDS", 2)
     user_alice.sendall(b"JOIN #foo\r\n")
 
-    while receive_line(user_alice) == b":mantatail PING :mantatail\r\n":
+    while receive_line(user_alice, 3) != b":mantatail PING :mantatail\r\n":
         pass
 
     user_alice.sendall(b"PONG :mantatail\r\n")


### PR DESCRIPTION
A ping message is currently sent to a user who has been inactive for 10 minutes, (`PING :mantatail`). 

If the client responds with `PONG :mantatail` within 5 seconds, the timer is restarted. Otherwise the client is disconnected from the server.

Disconnect reasons are still not supported, and the `QUIT` message therefore doesn't distinguish an intentional quit from a disconnect. This feature will be implemented in a future PR.