### PR TITLE
increase test timeout

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -39,7 +39,7 @@ jobs:
       - run: |
           pyflakes *.py tests
   pytest:
-    timeout-minutes: 2
+    timeout-minutes: 5
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
In  #58, the tests failed on MacOS even after I fixed everything. The problem was the 2 seconds timeout. The tests spent
- 47 seconds preparing the computer that ran the tests
- 9 seconds `git clone`ing Mantatail
- 2 seconds installing Python
- 57 seconds installing pytest
- 9 seconds running pytest

This makes for a total of 2min 4sec, so a timeout of 2 minutes was just too small.