### PR TITLE
Change logic for sending message to channel users

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -273,7 +273,7 @@ def handle_privmsg(state: mantatail.ServerState, user: mantatail.UserConnection,
         error_not_on_channel(user, receiver)
     else:
         privmsg_message = f"PRIVMSG {receiver} :{privmsg}"
-        channel.queue_message_to_chan_users(privmsg_message, user, False)
+        channel.queue_message_to_chan_users(privmsg_message, user, send_to_self=False)
 
 
 def handle_pong(state: mantatail.ServerState, user: mantatail.UserConnection, args: List[str]) -> None:

--- a/commands.py
+++ b/commands.py
@@ -227,7 +227,7 @@ def handle_kick(state: mantatail.ServerState, user: mantatail.UserConnection, ar
         kick_message = f"KICK {channel.name} {target_usr.nick} :{reason}"
 
     channel.queue_message_to_chan_users(kick_message, user)
-    channel.kick_user(target_usr)
+    channel.users.discard(target_usr)
     channel.operators.discard(target_usr)
 
     if len(channel.users) == 0:

--- a/mantatail.py
+++ b/mantatail.py
@@ -387,10 +387,7 @@ class Channel:
         is called with send_to_self = False.
         """
         for usr in self.users:
-            if not send_to_self:
-                if usr != sender:
-                    usr.send_que.put((message, sender.get_user_mask()))
-            else:
+            if usr != sender or send_to_self:
                 usr.send_que.put((message, sender.get_user_mask()))
 
 

--- a/mantatail.py
+++ b/mantatail.py
@@ -375,10 +375,6 @@ class Channel:
         """Checks if the user is the channel founder."""
         return user.user_name == self.founder
 
-    def kick_user(self, user_to_kick: UserConnection) -> None:
-        """Kicks user from the channel."""
-        self.users.discard(user_to_kick)
-
     def queue_message_to_chan_users(self, message: str, sender: UserConnection, send_to_self: bool = True) -> None:
         """
         Puts a message in the send queue of all users on the channel.


### PR DESCRIPTION
I think this improves the way messages are sent to channels. That way I don't have to repeat the same for loop in every single `handle_` function.