### PR TITLE
Fuzzer improvements

### DIFF
--- a/mantatail.py
+++ b/mantatail.py
@@ -96,6 +96,7 @@ class Listener:
         print(f"Mantatail running ({self.host}:{self.port})")
         while True:
             (user_socket, user_address) = self.listener_socket.accept()
+            print("Got connection from", user_address)
             client_thread = threading.Thread(
                 target=recv_loop, args=[self.state, user_address[0], user_socket], daemon=True
             )

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -139,8 +139,8 @@ def fuzzing_loop():
 mantatail_process = subprocess.Popen(
     ["python3", "-u", "mantatail.py"], cwd="../..", stdout=subprocess.PIPE, stderr=subprocess.STDOUT
 )
-print(mantatail_process.stdout.readline())  # Wait for mantatail to start
 try:
+    print(mantatail_process.stdout.readline())  # Wait for mantatail to start
     threading.Thread(target=output_reading_thread).start()
     fuzzing_loop()
 finally:

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -114,13 +114,8 @@ def fuzzing_loop():
             commands += " ".join(chosen_words) + "\n"
 
         sock = socket.socket()
-        try:
-            sock.connect(("localhost", 6667))
-        except ConnectionRefusedError:
-            sys.exit("Connection Refused: Start Mantatail in a separate terminal before running fuzzer.py")
-
+        sock.connect(("localhost", 6667))
         recent_commands.append((sock.getsockname(), commands))
-
         sock.sendall(commands.encode())
 
         try:

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -15,7 +15,6 @@ import collections
 import random
 import socket
 import subprocess
-import sys
 import threading
 
 

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -12,10 +12,16 @@ To fuzz:
 """
 
 import collections
+import os
 import random
 import socket
 import subprocess
 import threading
+from pathlib import Path
+
+# Change to the directory where this script is, so it doesn't matter whether
+# you run "python3 fuzzer.py" or "python3 tests/fuzzer/fuzzer.py"
+os.chdir(Path(__file__).parent)
 
 
 words = [

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -83,7 +83,7 @@ def print_commands(source_string):
     recent_commands_copy = list(recent_commands)
 
     for address_tuple, commands in recent_commands_copy:
-        if str(address_tuple) == source_string:  # lol
+        if str(address_tuple) == source_string:
             print(commands)
 
 

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -1,14 +1,22 @@
 """Simple fuzzer for MantaTail. See https://en.wikipedia.org/wiki/Fuzzing
 
-Usage:
-- Start MantaTail: python3 -m mantatail
-- Run fuzzer in another terminal: python3 fuzzer.py
-- Go back to MantaTail terminal, and see if you get errors.
+To fuzz:
+
+ 1. Make sure you don't have any unnecessary prints in mantatail. They will
+    cause the fuzzer to think that mantatail crashed; it doesn't try to
+    distinguish prints from error messages.
+
+ 2. Make sure that Mantatail isn't running.
+
+ 3. Run this script.
 """
 
-import socket
+import collections
 import random
+import socket
+import subprocess
 import sys
+import threading
 
 
 words = [
@@ -32,28 +40,108 @@ words = [
     "QUIT",
     "USER",
     "",
+    ":",
 ]
 
-print("Fuzzer starting. Please see if errors appear in the Mantatail terminal.")
+# Example of what Mantatail prints:
+#
+#    Got connection from ('127.0.0.1', 33224)
+#    Got connection from ('127.0.0.1', 33226)
+#    Got connection from ('127.0.0.1', 33228)
+#    Got connection from ('127.0.0.1', 33230)
+#    Exception in thread Thread-12909:
+#    Traceback (most recent call last):
+#      File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
+#        self.run()
+#      File "/usr/lib/python3.9/threading.py", line 892, in run
+#        self._target(*self._args, **self._kwargs)
+#      File "/home/akuli/MantaTail/mantatail.py", line 198, in recv_loop
+#        call_handler_function(state, user, args)
+#      File "/home/akuli/MantaTail/commands.py", line 133, in handle_mode
+#        process_channel_modes(state, user, args)
+#      File "/home/akuli/MantaTail/commands.py", line 396, in process_channel_modes
+#        if args[1][0] not in ["+", "-"]:
+#    IndexError: string index out of range
+#    Got connection from ('127.0.0.1', 33232)
+#    Got connection from ('127.0.0.1', 33234)
+#    Got connection from ('127.0.0.1', 33236)
+#    Got connection from ('127.0.0.1', 33238)
+#
+# To figure out what commands caused the crash, i.e. what was sent from address
+# tuple ('127.0.0.1', 33230), we keep the most recent address tuples and
+# commands here.
+recent_commands = collections.deque(maxlen=100)
 
-while True:
-    command = ""
-    for line_number in range(10000):
-        words_per_line = random.randint(1, 5)
-        chosen_words = [random.choice(words) for word_number in range(words_per_line)]
-        command += " ".join(chosen_words) + "\n"
 
-    sock = socket.socket()
-    try:
-        sock.connect(("localhost", 6667))
-    except ConnectionRefusedError:
-        sys.exit("Connection Refused: Start Mantatail in a separate terminal before running fuzzer.py")
+def print_commands(source_string):
+    # avoid looping over the deque while it might change
+    recent_commands_copy = list(recent_commands)
 
-    sock.sendall(command.encode())
+    for address_tuple, commands in recent_commands_copy:
+        if str(address_tuple) == source_string:  # lol
+            print(commands)
 
-    try:
-        sock.shutdown(socket.SHUT_RDWR)
-    except OSError:
-        # shutdown() sometimes fails on macos
-        pass
-    sock.close()
+
+def output_reading_thread():
+    source = None
+    output_lines = []
+
+    for line in mantatail_process.stdout:
+        line = line.decode()
+        if line.startswith("Got connection from"):
+            if source and output_lines:
+                print("\n\n")
+                print("-------- CRASH BEGIN --------")
+                print("*** Commands: ***")
+                print_commands(source)
+                print("*** Errors: ***")
+                print("".join(output_lines))
+                print("-------- CRASH END --------")
+
+            source = line.replace("Got connection from", "").strip()
+            output_lines.clear()
+        else:
+            output_lines.append(line)
+
+
+def fuzzing_loop():
+    print("Fuzzing...")
+    while True:
+        commands = ""
+        for line_number in range(500):
+            words_per_line = random.randint(1, 5)
+            chosen_words = [random.choice(words) for word_number in range(words_per_line)]
+            commands += " ".join(chosen_words) + "\n"
+
+        sock = socket.socket()
+        try:
+            sock.connect(("localhost", 6667))
+        except ConnectionRefusedError:
+            sys.exit("Connection Refused: Start Mantatail in a separate terminal before running fuzzer.py")
+
+        recent_commands.append((sock.getsockname(), commands))
+
+        sock.sendall(commands.encode())
+
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            # shutdown() sometimes fails on macos
+            pass
+        sock.close()
+
+
+# Start Mantatail in a separate process while fuzzing.
+#
+# -u tells python that prints should be displayed immediately.
+# This is the default when the output is going to a terminal, but not when it
+# is being captured by the subprocess module.
+mantatail_process = subprocess.Popen(
+    ["python3", "-u", "mantatail.py"], cwd="../..", stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+)
+print(mantatail_process.stdout.readline())  # Wait for mantatail to start
+try:
+    threading.Thread(target=output_reading_thread).start()
+    fuzzing_loop()
+finally:
+    mantatail_process.kill()


### PR DESCRIPTION
- When Mantatail crashes, print the commands that were sent to it
- Run Mantatail automatically, no longer two separate terminals needed
- Add `:` to the allowed words
