### PR TITLE
Implement logic for quit messages/reasons

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -274,10 +274,14 @@ def handle_quit(state: mantatail.ServerState, user: mantatail.UserConnection, ar
     """
     Command format: "QUIT"
 
-    Disconnects a user from the server by putting tuple (None, None) to their send queue.
+    Disconnects a user from the server by putting tuple (None, disconnect_reason: str) to their send queue.
     """
-    # TODO "if args: set args to reason"
-    user.send_que.put((None, None))
+    if args:
+        disconnect_reason = f"({args[0]})"
+    else:
+        disconnect_reason = "(Client quit.)"
+
+    user.send_que.put((None, disconnect_reason))
 
 
 def handle_privmsg(state: mantatail.ServerState, user: mantatail.UserConnection, args: List[str]) -> None:

--- a/commands.py
+++ b/commands.py
@@ -277,9 +277,9 @@ def handle_quit(state: mantatail.ServerState, user: mantatail.UserConnection, ar
     Disconnects a user from the server by putting tuple (None, disconnect_reason: str) to their send queue.
     """
     if args:
-        disconnect_reason = f"({args[0]})"
+        disconnect_reason = args[0]
     else:
-        disconnect_reason = "(Client quit.)"
+        disconnect_reason = "Client quit."
 
     user.send_que.put((None, disconnect_reason))
 

--- a/commands.py
+++ b/commands.py
@@ -279,7 +279,7 @@ def handle_quit(state: mantatail.ServerState, user: mantatail.UserConnection, ar
     if args:
         disconnect_reason = args[0]
     else:
-        disconnect_reason = "Client quit."
+        disconnect_reason = "Client quit"
 
     user.send_que.put((None, disconnect_reason))
 

--- a/mantatail.py
+++ b/mantatail.py
@@ -198,7 +198,7 @@ def recv_loop(state: ServerState, user_host: str, user_socket: socket.socket) ->
                             if command_lower == "quit":
                                 return
     finally:
-        disconnect_reason = "(Remote host closed the connection)"
+        disconnect_reason = "Remote host closed the connection"
         user.send_que.put((None, disconnect_reason))
 
 
@@ -232,7 +232,7 @@ class UserConnection:
         self.nick = "*"
         self.user_message: Optional[List[str]] = None  # Ex. AliceUsr 0 * Alice
         self.user_name: Optional[str] = None  # Ex. AliceUsr
-        self.send_que: queue.Queue[Tuple[str, str] | Tuple[None, Optional[str]]] = queue.Queue()
+        self.send_que: queue.Queue[Tuple[str, str] | Tuple[None, str]] = queue.Queue()
         self.que_thread = threading.Thread(target=self.send_queue_thread)
         self.que_thread.start()
         self.pong_received = False
@@ -260,7 +260,7 @@ class UserConnection:
 
             if message is None:
                 disconnect_reason = prefix
-                quit_message = f"QUIT :Quit: {disconnect_reason}"
+                quit_message = f"QUIT :Quit: ({disconnect_reason})"
                 with self.state.lock:
                     self.queue_quit_message_for_other_users(quit_message)
                     if self.nick != "*":
@@ -281,7 +281,7 @@ class UserConnection:
                 try:
                     self.send_string_to_client(message, prefix)
                 except:
-                    disconnect_reason = "(Remote host closed the connection)"
+                    disconnect_reason = "Remote host closed the connection"
                     self.send_que.put((None, disconnect_reason))
 
     def queue_quit_message_for_other_users(self, quit_message: str) -> None:
@@ -348,7 +348,7 @@ class UserConnection:
         If no PONG response has been received, the server closes the connection to the client.
         """
         if not self.pong_received:
-            disconnect_reason = "(Ping timeout...)"
+            disconnect_reason = "Ping timeout..."
             self.send_que.put((None, disconnect_reason))
         else:
             self.pong_received = False

--- a/mantatail.py
+++ b/mantatail.py
@@ -181,7 +181,7 @@ def recv_loop(state: ServerState, user_host: str, user_socket: socket.socket) ->
                         commands.handle_pong(state, user, args)
                     else:
                         if command_lower == "quit":
-                            disconnect_reason = "Remote host closed the connection"
+                            disconnect_reason = "Client quit"
                             return
                         else:
                             commands.error_not_registered(user)
@@ -262,7 +262,7 @@ class UserConnection:
 
             if message is None:
                 disconnect_reason = prefix
-                quit_message = f"QUIT :Quit: ({disconnect_reason})"
+                quit_message = f"QUIT :Quit: {disconnect_reason}"
                 with self.state.lock:
                     self.queue_quit_message_for_other_users(quit_message)
                     if self.nick != "*":

--- a/mantatail.py
+++ b/mantatail.py
@@ -237,7 +237,7 @@ class UserConnection:
         self.user_message: Optional[List[str]] = None  # Ex. AliceUsr 0 * Alice
         self.user_name: Optional[str] = None  # Ex. AliceUsr
         self.away: Optional[str] = None  # None = user not away, str = user away
-        self.send_que: queue.Queue[Tuple[str, str] | Tuple[None, None]] = queue.Queue()
+        self.send_que: queue.Queue[Tuple[str, str] | Tuple[None, str]] = queue.Queue()
         self.que_thread = threading.Thread(target=self.send_queue_thread)
         self.que_thread.start()
         self.pong_received = False

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 import random
 import socket
@@ -958,7 +959,11 @@ def test_sudden_disconnect(run_server):
 
     nc.close()
 
-    assert receive_line(nc2) == b":nc!nc@127.0.0.1 QUIT :Quit: Connection reset by peer\r\n"
+    if sys.platform == "win32":
+        # strerror is platform-specific, and also language specific on windows
+        assert receive_line(nc2).startswith(b":nc!nc@... QUIT :Quit: ")
+    else:
+        assert receive_line(nc2) == b":nc!nc@127.0.0.1 QUIT :Quit: Connection reset by peer\r\n"
 
 
 # Issue #77

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -655,7 +655,7 @@ def test_quit_before_registering():
     with socket.socket() as nc:
         nc.connect(("localhost", 6667))  # nc localhost 6667
         nc.sendall(b"QUIT\n")
-        assert receive_line(nc) == b":QUIT :Quit: (Remote host closed the connection)\r\n"
+        assert receive_line(nc) == b":QUIT :Quit: Client quit\r\n"
 
 
 def test_quit_reasons():
@@ -698,16 +698,16 @@ def test_quit_reasons():
     time.sleep(0.1)
 
     nc.sendall(b"QUIT\n")
-    assert receive_line(nc4) == b":nc!nc@127.0.0.1 QUIT :Quit: (Client quit.)\r\n"
+    assert receive_line(nc4) == b":nc!nc@127.0.0.1 QUIT :Quit: Client quit\r\n"
 
     nc2.sendall(b"QUIT :Reason\n")
-    assert receive_line(nc4) == b":nc2!nc2@127.0.0.1 QUIT :Quit: (Reason)\r\n"
+    assert receive_line(nc4) == b":nc2!nc2@127.0.0.1 QUIT :Quit: Reason\r\n"
 
     nc3.sendall(b"QUIT :Reason with many words\n")
-    assert receive_line(nc4) == b":nc3!nc3@127.0.0.1 QUIT :Quit: (Reason with many words)\r\n"
+    assert receive_line(nc4) == b":nc3!nc3@127.0.0.1 QUIT :Quit: Reason with many words\r\n"
 
     nc4.sendall(b"QUIT Many words but no colon\n")
-    assert receive_line(nc4) == b":nc4!nc4@127.0.0.1 QUIT :Quit: (Many)\r\n"
+    assert receive_line(nc4) == b":nc4!nc4@127.0.0.1 QUIT :Quit: Many\r\n"
 
 
 def test_no_nickname_given():
@@ -919,7 +919,7 @@ def test_sudden_disconnect(run_server):
 
     nc.close()
 
-    assert receive_line(nc2) == b":nc!nc@127.0.0.1 QUIT :Quit: (Connection reset by peer)\r\n"
+    assert receive_line(nc2) == b":nc!nc@127.0.0.1 QUIT :Quit: Connection reset by peer\r\n"
 
 
 # Issue #77

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -919,7 +919,7 @@ def test_sudden_disconnect(run_server):
 
     nc.close()
 
-    assert receive_line(nc2) == b":nc!nc@127.0.0.1 QUIT :Quit: (Remote host closed the connection)\r\n"
+    assert receive_line(nc2) == b":nc!nc@127.0.0.1 QUIT :Quit: (Connection reset by peer)\r\n"
 
 
 # Issue #77

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -961,7 +961,7 @@ def test_sudden_disconnect(run_server):
 
     if sys.platform == "win32":
         # strerror is platform-specific, and also language specific on windows
-        assert receive_line(nc2).startswith(b":nc!nc@... QUIT :Quit: ")
+        assert receive_line(nc2).startswith(b":nc!nc@127.0.0.1 QUIT :Quit: ")
     else:
         assert receive_line(nc2) == b":nc!nc@127.0.0.1 QUIT :Quit: Connection reset by peer\r\n"
 

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -658,6 +658,58 @@ def test_quit_before_registering():
         assert receive_line(nc) == b":QUIT :Quit: (Remote host closed the connection)\r\n"
 
 
+def test_quit_reasons():
+    nc = socket.socket()
+    nc.connect(("localhost", 6667))
+    nc.sendall(b"NICK nc\n")
+    nc.sendall(b"USER nc 0 * :netcat\n")
+    nc.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc) != b":mantatail 366 nc #foo :End of /NAMES list.\r\n":
+        pass
+
+    nc2 = socket.socket()
+    nc2.connect(("localhost", 6667))
+    nc2.sendall(b"NICK nc2\n")
+    nc2.sendall(b"USER nc2 0 * :netcat\n")
+    nc2.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc2) != b":mantatail 366 nc2 #foo :End of /NAMES list.\r\n":
+        pass
+
+    nc3 = socket.socket()
+    nc3.connect(("localhost", 6667))
+    nc3.sendall(b"NICK nc3\n")
+    nc3.sendall(b"USER nc3 0 * :netcat\n")
+    nc3.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc3) != b":mantatail 366 nc3 #foo :End of /NAMES list.\r\n":
+        pass
+
+    nc4 = socket.socket()
+    nc4.connect(("localhost", 6667))
+    nc4.sendall(b"NICK nc4\n")
+    nc4.sendall(b"USER nc4 0 * :netcat\n")
+    nc4.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc4) != b":mantatail 366 nc4 #foo :End of /NAMES list.\r\n":
+        pass
+
+    time.sleep(0.1)
+
+    nc.sendall(b"QUIT\n")
+    assert receive_line(nc4) == b":nc!nc@127.0.0.1 QUIT :Quit: (Client quit.)\r\n"
+
+    nc2.sendall(b"QUIT :Reason\n")
+    assert receive_line(nc4) == b":nc2!nc2@127.0.0.1 QUIT :Quit: (Reason)\r\n"
+
+    nc3.sendall(b"QUIT :Reason with many words\n")
+    assert receive_line(nc4) == b":nc3!nc3@127.0.0.1 QUIT :Quit: (Reason with many words)\r\n"
+
+    nc4.sendall(b"QUIT Many words but no colon\n")
+    assert receive_line(nc4) == b":nc4!nc4@127.0.0.1 QUIT :Quit: (Many)\r\n"
+
+
 def test_no_nickname_given():
     with socket.socket() as nc:
         nc.connect(("localhost", 6667))


### PR DESCRIPTION
Since the `message` queued in a users `send_que` is never `None`, I decided that the second `None` in the tuple was not necessarily needed. Therefore I saw it as the best option to send a quit message/reason.