### PR TITLE
Implement capability feature away-notify

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -261,8 +261,13 @@ def handle_away(state: mantatail.ServerState, user: mantatail.UserConnection, ar
 
     receivers = user.get_users_sharing_channel()
 
+    if not args:
+        away_parameter = ""
+    else:
+        away_parameter = args[0]
+
     # args[0] == "" happens when user sends "AWAY :", which indicates they are no longer away.
-    if not args or args[0] == "":
+    if not away_parameter:
         (unaway_num, unaway_info) = irc_responses.RPL_UNAWAY
         msg_to_self = f"{unaway_num} {user.nick} {unaway_info}"
         user.away = None
@@ -272,12 +277,6 @@ def handle_away(state: mantatail.ServerState, user: mantatail.UserConnection, ar
         user.away = args[0]
 
     user.send_que.put((msg_to_self, "mantatail"))
-
-    if not args:
-        away_parameter = ""
-    else:
-        away_parameter = args[0]
-
     away_notify_msg = f"AWAY :{away_parameter}"
 
     for receiver in receivers:

--- a/mantatail.py
+++ b/mantatail.py
@@ -16,7 +16,7 @@ import commands
 import irc_responses
 
 TIMER_SECONDS = 600
-CAP_LS: List[str] = ["cap-notify"]
+CAP_LS: List[str] = ["away-notify", "cap-notify"]
 
 
 class ServerState:

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -827,7 +827,7 @@ def test_away_notify(run_server):
     while receive_line(nc2) != b":nc4!nc4@127.0.0.1 AWAY :I am away\r\n":
         pass
 
-    receive_line(nc3)  # nc4 JOIN message
+    assert b"JOIN" in receive_line(nc3)  # nc4 JOIN message
 
     # Makes sure that nc3 doesn't receive an away message from nc
     with pytest.raises(socket.timeout):

--- a/tests/test_mantatail.py
+++ b/tests/test_mantatail.py
@@ -699,13 +699,13 @@ def test_cap_commands(run_server):
     assert receive_line(nc) == b":mantatail 461 * CAP :Not enough parameters\r\n"
 
     nc.sendall(b"CAP LS\n")
-    assert receive_line(nc) == b":mantatail CAP * LS :cap-notify\r\n"
+    assert receive_line(nc) == b":mantatail CAP * LS :away-notify cap-notify\r\n"
 
     nc.sendall(b"CAP LIST\n")
     assert receive_line(nc) == b":mantatail CAP * LIST :\r\n"
 
     nc.sendall(b"CAP LS 302\n")
-    assert receive_line(nc) == b":mantatail CAP * LS :cap-notify\r\n"
+    assert receive_line(nc) == b":mantatail CAP * LS :away-notify cap-notify\r\n"
 
     nc.sendall(b"CAP LIST\n")
     assert receive_line(nc) == b":mantatail CAP * LIST :cap-notify\r\n"
@@ -725,7 +725,7 @@ def test_cap_req(run_server):
     nc = socket.socket()
     nc.connect(("localhost", 6667))
     nc.sendall(b"CAP LS\n")
-    assert receive_line(nc) == b":mantatail CAP * LS :cap-notify\r\n"
+    assert receive_line(nc) == b":mantatail CAP * LS :away-notify cap-notify\r\n"
 
     nc.sendall(b"CAP REQ\n")
     with pytest.raises(socket.timeout):
@@ -748,6 +748,90 @@ def test_cap_req(run_server):
 
     nc.sendall(b"CAP LIST\n")
     assert receive_line(nc) == b":mantatail CAP * LIST :cap-notify\r\n"
+
+    nc.sendall(b"CAP REQ :away-notify\n")
+    assert receive_line(nc) == b":mantatail CAP * ACK :away-notify\r\n"
+
+    nc.sendall(b"CAP LIST\n")
+
+    while True:
+        received = receive_line(nc)
+        if b"LIST" in received:
+            received_no_colons = received.replace(b":", b"")
+            assert compare_if_word_match_in_any_order(
+                received_no_colons, b"mantatail CAP * LIST cap-notify away-notify\r\n"
+            )
+            break
+
+
+def test_away_notify(run_server):
+    nc = socket.socket()
+    nc.connect(("localhost", 6667))
+    nc.sendall(b"CAP LS\n")
+    assert receive_line(nc) == b":mantatail CAP * LS :away-notify cap-notify\r\n"
+
+    nc.sendall(b"NICK nc\n")
+    nc.sendall(b"USER nc 0 * :netcat\n")
+    nc.sendall(b"CAP END\n")
+    nc.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc) != b":mantatail 366 nc #foo :End of /NAMES list.\r\n":
+        pass
+
+    # Negotiates away-notify with server
+    nc2 = socket.socket()
+    nc2.connect(("localhost", 6667))
+    nc2.sendall(b"CAP REQ away-notify\n")
+    assert receive_line(nc2) == b":mantatail CAP * ACK :away-notify\r\n"
+    nc2.sendall(b"NICK nc2\n")
+    nc2.sendall(b"USER nc2 0 * :netcat\n")
+    nc2.sendall(b"CAP END\n")
+    nc2.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc2) != b":mantatail 366 nc2 #foo :End of /NAMES list.\r\n":
+        pass
+
+    # Does not negotiate with server
+    nc3 = socket.socket()
+    nc3.connect(("localhost", 6667))
+    nc3.sendall(b"NICK nc3\n")
+    nc3.sendall(b"USER nc3 0 * :netcat\n")
+    nc3.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc3) != b":mantatail 366 nc3 #foo :End of /NAMES list.\r\n":
+        pass
+
+    # Join messages from other clients
+    receive_line(nc)
+    receive_line(nc2)
+
+    time.sleep(0.1)
+
+    nc.sendall(b"AWAY :This is an away message\n")
+
+    assert receive_line(nc2) == b":nc!nc@127.0.0.1 AWAY :This is an away message\r\n"
+
+    # Makes sure that nc3 doesn't receive an away message from nc
+    with pytest.raises(socket.timeout):
+        receive_line(nc3)
+
+    nc4 = socket.socket()
+    nc4.connect(("localhost", 6667))
+    nc4.sendall(b"NICK nc4\n")
+    nc4.sendall(b"USER nc4 0 * :netcat\n")
+
+    nc4.sendall(b"AWAY :I am away\n")
+
+    nc4.sendall(b"JOIN #foo\n")
+
+    while receive_line(nc2) != b":nc4!nc4@127.0.0.1 AWAY :I am away\r\n":
+        pass
+
+    receive_line(nc3)  # nc4 JOIN message
+
+    # Makes sure that nc3 doesn't receive an away message from nc
+    with pytest.raises(socket.timeout):
+        receive_line(nc3)
 
 
 def test_quit_before_registering(run_server):


### PR DESCRIPTION
Note:

This PR implements the away-notify feature to the extent possible on a server without the [`WHO`](https://modern.ircdocs.horse/#who-message) feature.

This means that:

- If user `Foo` and user `Bar` are one `#chan`, and user `Foo` sets their status to `AWAY`, `Bar` will get an AWAY message if their client has `away-notify` enabled. If the feature is disabled, they get no message.
- If `Bar` is on `#chan`, user `Foo` already has their status set to away and joins `#chan`, `Bar` will get an away message from `Foo` if away-notify is enabled.
- If `Foo` is on `#chan` and has their status set to away, and `Bar` (with `away-notify` enabled) joins `#chan`, `Bar` will not see that `Foo` is away. 

The reason for bullet 3 is that when `JOIN`ing a channel, the client should send a `WHO` message to receive a list of the channel users and their statuses.
Since `WHO` is not in the scope of this PR, I will have to exclude this feature for now, and implement it in a future `WHO` PR.

Noted in #113 