### PR TITLE
fix nick change bug

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -229,7 +229,9 @@ def handle_nick(state: server.State, user: server.UserConnection, args: List[str
     if not re.fullmatch(nick_regex, new_nick):
         errors.erroneus_nickname(user, new_nick)
         return
-    elif new_nick in state.connected_users.keys():
+
+    existing_user = state.find_user(new_nick)
+    if existing_user is not None and existing_user != user:
         errors.nick_in_use(user, new_nick)
     else:
         if user.nick == "*":

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -51,9 +51,13 @@ def test_nick_change(user_alice, user_bob, helpers):
         == b":NewNick!AliceUsr@127.0.0.1 PRIVMSG #foo :Alice should have a new user mask\r\n"
     )
 
+    user_alice.sendall(b"NICK :newnick\r\n")
+    assert helpers.receive_line(user_alice) == b":NewNick!AliceUsr@127.0.0.1 NICK :newnick\r\n"
+    assert helpers.receive_line(user_bob) == b":NewNick!AliceUsr@127.0.0.1 NICK :newnick\r\n"
+
     user_alice.sendall(b"NICK :NEWNICK\r\n")
-    assert helpers.receive_line(user_alice) == b":NewNick!AliceUsr@127.0.0.1 NICK :NEWNICK\r\n"
-    assert helpers.receive_line(user_bob) == b":NewNick!AliceUsr@127.0.0.1 NICK :NEWNICK\r\n"
+    assert helpers.receive_line(user_alice) == b":newnick!AliceUsr@127.0.0.1 NICK :NEWNICK\r\n"
+    assert helpers.receive_line(user_bob) == b":newnick!AliceUsr@127.0.0.1 NICK :NEWNICK\r\n"
 
     user_alice.sendall(b"NICK :NEWNICK\r\n")
 


### PR DESCRIPTION
The problem was `new_nick in state.connected_users.keys()`. The keys of `connected_users` are **lowercased** nicks, not just nicks. That's why switching to lower-case `bob` behaved differently from nick changes that were tested before. I replaced it with `find_user()`, which contains the logic for dealing with this.

Fixes #125 