### PR TITLE
WHOIS support

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -469,6 +469,24 @@ def handle_who(state: server.State, user: server.UserConnection, args: List[str]
     user.send_que.put((end_of_who_message, "mantatail"))
 
 
+def handle_whois(state: server.State, user: server.UserConnection, args: List[str]) -> None:
+    if not args:
+        errors.not_enough_params(user, "WHOIS")
+        return
+
+    whois_user = None
+
+    if len(args) == 2:
+        whois_user = state.find_user(args[1])
+    else:
+        pass
+        
+
+    if not whois_user:
+        errors.no_such_nick_channel(user, whois_user)
+        ---
+
+
 def handle_pong(state: server.State, user: server.UserConnection, args: List[str]) -> None:
     """
     Handles client's PONG response to a PING message sent from the server.

--- a/commands.py
+++ b/commands.py
@@ -485,7 +485,9 @@ def handle_whois(state: server.State, user: server.UserConnection, args: List[st
     elif len(args) >= 2:
         param_2_user = state.find_user(args[1])
 
-        if not param_1_user and args[0] != "mantatail":
+        if (
+            not param_1_user and args[0] != "mantatail.chat"
+        ):  # TODO: Update "mantatail.chat" when/if server gets an official name.
             errors.no_such_server(user, args[0])
         elif not param_2_user:
             errors.no_such_nick_channel(user, args[1])

--- a/commands.py
+++ b/commands.py
@@ -474,17 +474,24 @@ def handle_whois(state: server.State, user: server.UserConnection, args: List[st
         errors.not_enough_params(user, "WHOIS")
         return
 
-    whois_user = None
+    param_1_user = state.find_user(args[0])
 
-    if len(args) == 2:
-        whois_user = state.find_user(args[1])
-    else:
-        pass
-        
+    if len(args) == 1:
+        if not param_1_user:
+            errors.no_such_nick_channel(user, args[0])
+        else:
+            whois_reply(user, param_1_user)
 
-    if not whois_user:
-        errors.no_such_nick_channel(user, whois_user)
-        ---
+    elif len(args) >= 2:
+        param_2_user = state.find_user(args[1])
+
+        if not param_1_user and args[0] != "mantatail":
+            errors.no_such_server(user, args[0])
+        elif not param_2_user:
+            errors.no_such_nick_channel(user, args[1])
+
+        else:
+            whois_reply(user, param_2_user)
 
 
 def handle_pong(state: server.State, user: server.UserConnection, args: List[str]) -> None:
@@ -517,6 +524,17 @@ def privmsg_to_user(state: server.State, sender: server.UserConnection, receiver
     if receiver_usr.away:
         away_message = f"301 {sender.nick} {receiver_usr.nick} :{receiver_usr.away}"
         sender.send_que.put((away_message, "mantatail"))
+
+
+def whois_reply(user: server.UserConnection, whois_user: server.UserConnection) -> None:
+    whoisuser_message = (
+        f"311 {user.nick} {whois_user.nick} {whois_user.user_name} {whois_user.host} * :{whois_user.real_name}"
+    )
+
+    endofwhois_message = f"318 {user.nick} {whois_user.nick} :End of /WHOIS list."
+
+    user.send_que.put((whoisuser_message, "mantatail"))
+    user.send_que.put((endofwhois_message, "mantatail"))
 
 
 def rpl_welcome(user: server.UserConnection) -> None:

--- a/errors.py
+++ b/errors.py
@@ -85,6 +85,12 @@ def banned_from_chan(user: server.UserConnection, channel: server.Channel) -> No
     user.send_que.put((message, "mantatail"))
 
 
+def no_such_server(user: server.UserConnection, server_name: str) -> None:
+    """Sent when a user provides a non-existing server as an argument in a commant."""
+    message = f"402 {user.nick} {server_name} :No such server"
+    user.send_que.put((message, "mantatail"))
+
+
 def no_such_channel(user: server.UserConnection, channel_name: str) -> None:
     """Sent when a user provides a non-existing channel as an argument in a command."""
     message = f"403 {user.nick} {channel_name} :No such channel"

--- a/errors.py
+++ b/errors.py
@@ -86,7 +86,7 @@ def banned_from_chan(user: server.UserConnection, channel: server.Channel) -> No
 
 
 def no_such_server(user: server.UserConnection, server_name: str) -> None:
-    """Sent when a user provides a non-existing server as an argument in a commant."""
+    """Sent when a user provides a non-existing server as an argument in a command."""
     message = f"402 {user.nick} {server_name} :No such server"
     user.send_que.put((message, "mantatail"))
 

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -201,6 +201,10 @@ def test_whois_command(user_alice, user_bob, user_charlie, helpers):
     assert helpers.receive_line(user_alice) == b":mantatail 311 Alice Bob BobUsr 127.0.0.1 * :Bob's real name\r\n"
     assert helpers.receive_line(user_alice) == b":mantatail 318 Alice Bob :End of /WHOIS list.\r\n"
 
+    user_alice.sendall(b"WHOIS mantatail.chat Bob\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 311 Alice Bob BobUsr 127.0.0.1 * :Bob's real name\r\n"
+    assert helpers.receive_line(user_alice) == b":mantatail 318 Alice Bob :End of /WHOIS list.\r\n"
+
 
 def test_send_privmsg_to_user(user_alice, user_bob, helpers):
     user_alice.sendall(b"PRIVMSG Bob :This is a private message\r\n")
@@ -272,18 +276,6 @@ def test_message_starting_with_colon(user_alice, user_bob, helpers):
     # Alice sends ":O"
     user_alice.sendall(b"PRIVMSG #foo ::O\r\n")
     assert helpers.receive_line(user_bob) == b":Alice!AliceUsr@127.0.0.1 PRIVMSG #foo ::O\r\n"
-
-
-def test_whois_reply(user_alice, user_bob, helpers):
-    user_alice.sendall(b"WHOIS Alice\r\n")
-    assert helpers.receive_line(user_alice) == b":mantatail 311 Alice Alice AliceUsr 127.0.0.1 * :Alice's real name\r\n"
-    assert helpers.receive_line(user_alice) == b":mantatail 312 Alice Alice Mantatail :Running locally\r\n"
-    assert helpers.receive_line(user_alice) == b":mantatail 318 Alice Alice :End of /WHOIS list.\r\n"
-
-    user_alice.sendall(b"WHOIS Bob\r\n")
-    assert helpers.receive_line(user_alice) == b":mantatail 311 Bob Bob BobUsr 127.0.0.1 * :Bob's real name\r\n"
-    assert helpers.receive_line(user_alice) == b":mantatail 312 Bob Bob Mantatail :Running locally\r\n"
-    assert helpers.receive_line(user_alice) == b":mantatail 318 Bob Bob :End of /WHOIS list.\r\n"
 
 
 ### Netcat tests

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -172,6 +172,28 @@ def test_who_command(user_alice, user_bob, user_charlie, helpers):
     assert helpers.receive_line(user_charlie) == b":mantatail 315 Charlie Alice :End of /WHO list.\r\n"
 
 
+def test_whois_command(user_alice, user_bob, user_charlie, helpers):
+    user_alice.sendall(b"WHOIS\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 461 Alice WHOIS :Not enough parameters\r\n"
+
+    user_alice.sendall(b"WHOIS Debora\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 401 Alice Debora :No such nick/channel\r\n"
+
+    user_alice.sendall(b"WHOIS Bob\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 311 Alice Bob BobUsr 127.0.0.1 * :Bob's real name\r\n"
+    assert helpers.receive_line(user_alice) == b":mantatail 318 Alice Bob :End of /WHOIS list.\r\n"
+
+    user_alice.sendall(b"WHOIS Bob Debora\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 401 Alice Debora :No such nick/channel\r\n"
+
+    user_alice.sendall(b"WHOIS Debora Bob\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 402 Alice Debora :No such server\r\n"
+
+    user_alice.sendall(b"WHOIS Charlie Bob\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 311 Alice Bob BobUsr 127.0.0.1 * :Bob's real name\r\n"
+    assert helpers.receive_line(user_alice) == b":mantatail 318 Alice Bob :End of /WHOIS list.\r\n"
+
+
 def test_send_privmsg_to_user(user_alice, user_bob, helpers):
     user_alice.sendall(b"PRIVMSG Bob :This is a private message\r\n")
     assert helpers.receive_line(user_bob) == b":Alice!AliceUsr@127.0.0.1 PRIVMSG Bob :This is a private message\r\n"

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -244,6 +244,18 @@ def test_message_starting_with_colon(user_alice, user_bob, helpers):
     assert helpers.receive_line(user_bob) == b":Alice!AliceUsr@127.0.0.1 PRIVMSG #foo ::O\r\n"
 
 
+def test_whois_reply(user_alice, user_bob, helpers):
+    user_alice.sendall(b"WHOIS Alice\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 311 Alice Alice AliceUsr 127.0.0.1 * :Alice's real name\r\n"
+    assert helpers.receive_line(user_alice) == b":mantatail 312 Alice Alice Mantatail :Running locally\r\n"
+    assert helpers.receive_line(user_alice) == b":mantatail 318 Alice Alice :End of /WHOIS list.\r\n"
+
+    user_alice.sendall(b"WHOIS Bob\r\n")
+    assert helpers.receive_line(user_alice) == b":mantatail 311 Bob Bob BobUsr 127.0.0.1 * :Bob's real name\r\n"
+    assert helpers.receive_line(user_alice) == b":mantatail 312 Bob Bob Mantatail :Running locally\r\n"
+    assert helpers.receive_line(user_alice) == b":mantatail 318 Bob Bob :End of /WHOIS list.\r\n"
+
+
 ### Netcat tests
 # netcat sends \n line endings, but is fine receiving \r\n
 def test_connect_via_netcat(run_server, helpers):


### PR DESCRIPTION
This should provide enough support of `WHOIS` for Mantaray tests running in https://github.com/Akuli/mantaray/pull/244.

The functionality is based on Libera, where you can add more than one parameter.

With one parameter, the server checks if the parameter corresponds to an existing user.
With two parameters, it checks if param1 is an existing server. If it's not, the user will get a `402 No such server`.

Fixes #128 